### PR TITLE
Fix time in the az encoder acquisition code and remove leftover zipping function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # azimuthalencoder
 H7 code for azimuthal encoder sampling at 1kHz. Currently no PPS alignment.
 
-#### Latest update: Tuesday, January 14th 2025
+#### Latest update: Tuesday, June 10th 2025
 
 ## System overview:
 - STM H723ZG microcontroller
@@ -36,9 +36,8 @@ Python script saves a .csv file with the filename given in the script in the dir
 ### | ES1 | ... | ES100 | CT1 | ... | CT100 | PN | T1 | T2 |
 - ES = Encoder sample/data
 - CT = Clock tick at time of querying corresponding to each encoder sample
-- PN = Packet number (increments by 1 and rolls over at 2^16-1)
 - T1 = Real time (accurate to 1/10th of a second) when data has been received from UDP socket (added by computer)
-- T2 = Number of nanoseconds elapsed since start of the unix epoch (Jan 1, 1970) modulo 1,000,000 (i.e. the number of nanoseconds into the current second) when data is received from UDP socket (added by computer)
+
 
 ## System diagram
 ![Azimuthal Encoder-6](https://github.com/user-attachments/assets/28ff7027-73ce-4680-9452-8b50fd2c9dd6)

--- a/az_encoder/requirements.txt
+++ b/az_encoder/requirements.txt
@@ -1,0 +1,1 @@
+schedule

--- a/az_encoder/scripts/cgem_az_encoder.py
+++ b/az_encoder/scripts/cgem_az_encoder.py
@@ -26,7 +26,7 @@ Main Loop
 3. Handles interruptions (e.g., `KeyboardInterrupt`) gracefully by closing resources.
 
 @Author: Shuyu van Kerkwijk and Pedro Villalba-González
-@Date: March 20th, 2025
+@Date: June 10th, 2025
 @e-mail: pedrovg@phas.ubc.ca
 @status: Deployment
 """
@@ -250,7 +250,50 @@ def rotate_file():
 
 
 def process_payload(payload, current_time):
-    """Process the incoming payload and write to the current file."""
+    """ Process binary payload from az encoder.
+    
+    Process an incoming binary payload, extract sample and timestamp values, 
+    and append them—along with the current time—to a CSV file.
+
+    Parameters
+    ----------
+    payload : bytes
+        Raw binary data containing interleaved sample and timestamp segments.
+    current_time : int
+        The current time to be appended to the CSV record.
+
+    Globals
+    -------
+    filename : str
+        Path to the CSV file where processed data will be written.
+    logger : logging.Logger
+        Logger used for reporting malformed segments.
+
+    Returns
+    -------
+    None
+        This function only writes data to the CSV and does not return a value.
+
+    Raises
+    ------
+    ValueError
+        If conversion of a hex segment to integer fails; such segments are logged 
+        and skipped, but the exception is not propagated.
+
+    Notes
+    -----
+    1. Converts the entire payload to a hex string.
+    2. Splits the hex string on the marker `'89abcdef'` to isolate individual segments.
+    3. For each segment:
+       - Skips if shorter than 16 hex characters.
+       - Extracts and reorders bytes to form two integers:
+         - `sample_int` from bytes at positions [2:4], [0:2], [5:6]
+         - `time_int` from bytes at positions [14:16], [12:14], [10:12], [8:10]
+       - Logs and ignores any segment that raises `ValueError`.
+    4. Aggregates all parsed samples and timestamps into a single list.
+    5. Appends the supplied `current_time` to this list.
+    6. Opens `filename` in append mode and writes the list as a new CSV row.
+   """
     global filename
 
     payload_hex = payload.hex()

--- a/az_encoder/scripts/cgem_az_encoder.py
+++ b/az_encoder/scripts/cgem_az_encoder.py
@@ -281,7 +281,6 @@ def process_payload(payload):
 # Scheduling Tasks
 schedule.every().hour.at(":00").do(rotate_file)
 schedule.every().hour.at(":30").do(rotate_file)
-schedule.every().day.at("00:01").do(zip_previous_day_files)
 
 # Configure UDP socket
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/az_encoder/scripts/cgem_az_encoder.py
+++ b/az_encoder/scripts/cgem_az_encoder.py
@@ -253,8 +253,6 @@ def process_payload(payload):
     """Process the incoming payload and write to the current file."""
     global filename
 
-    current_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")
-    current_time_ns = time.time_ns() % 1_000_000_000
     payload_hex = payload.hex()
 
     samples_hex = payload_hex.split("89abcdef")
@@ -272,9 +270,9 @@ def process_payload(payload):
         except ValueError as e:
             logger.error(f"Malformed payload segment {sample_hex}: {e}")
 
+    current_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")   
     samples_int.extend(times_int)
     samples_int.append(current_time)
-    samples_int.append(current_time_ns)
 
     with open(filename, mode="a", newline="") as file:
         writer = csv.writer(file)

--- a/az_encoder/scripts/cgem_az_encoder.py
+++ b/az_encoder/scripts/cgem_az_encoder.py
@@ -249,13 +249,13 @@ def rotate_file():
     logger.info(f"Rotated to new file: {filename}")
 
 
-def process_payload(payload):
+def process_payload(payload, current_time):
     """Process the incoming payload and write to the current file."""
     global filename
 
     payload_hex = payload.hex()
-
     samples_hex = payload_hex.split("89abcdef")
+   
     samples_int = []
     times_int = []
 
@@ -270,7 +270,7 @@ def process_payload(payload):
         except ValueError as e:
             logger.error(f"Malformed payload segment {sample_hex}: {e}")
 
-    current_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")   
+      
     samples_int.extend(times_int)
     samples_int.append(current_time)
 
@@ -296,8 +296,8 @@ try:
         schedule.run_pending()
         data, addr = sock.recvfrom(PACKET_SIZE)
         if addr[0] == UDP_IP and addr[1] == UDP_PORT:
-            data_payload = data[0:]  # UDP header is removed
-            process_payload(data_payload)
+            current_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f") 
+            process_payload(data[0:], current_time)
         else:
             logger.info(f"Ignored packet from {addr}")
 except KeyboardInterrupt:

--- a/az_encoder/scripts/cgem_az_encoder.py
+++ b/az_encoder/scripts/cgem_az_encoder.py
@@ -259,7 +259,7 @@ def process_payload(payload, current_time):
     ----------
     payload : bytes
         Raw binary data containing interleaved sample and timestamp segments.
-    current_time : int
+    current_time : str
         The current time to be appended to the CSV record.
 
     Globals

--- a/az_encoder/scripts/cgem_az_encoder.py
+++ b/az_encoder/scripts/cgem_az_encoder.py
@@ -248,33 +248,6 @@ def rotate_file():
     filename = generate_filename()
     logger.info(f"Rotated to new file: {filename}")
 
-def zip_previous_day_files():
-    """Zip all files from the previous day."""
-    previous_day = (datetime.utcnow() - timedelta(days=1)).strftime(FOLDER_TIMESTAMP_FORMAT)
-    previous_folder_name = f"{previous_day}_cgem_az_encoder"
-    previous_full_path = os.path.join(BASE_PATH, previous_folder_name)
-
-    if not os.path.exists(previous_full_path):
-        logger.warning(f"No data folder found for the previous day: {previous_full_path}")
-        return
-
-    zip_filename = os.path.join(BASE_PATH, f"{previous_day}_cgem_az_encoder.zip")
-    logger.info(f"Zipping files from {previous_full_path} into {zip_filename}...")
-
-    try:
-        with zipfile.ZipFile(zip_filename, "w") as zipf:
-            for root, _, files in os.walk(previous_full_path):
-                for file in files:
-                    zipf.write(os.path.join(root, file), arcname=file)
-
-        logger.info("Zipping completed. Cleaning up files...")
-        for root, _, files in os.walk(previous_full_path):
-            for file in files:
-                os.remove(os.path.join(root, file))
-
-        os.rmdir(previous_full_path)
-    except Exception as e:
-        logger.error(f"Error during zipping or cleanup: {e}", exc_info=True)
 
 def process_payload(payload):
     """Process the incoming payload and write to the current file."""
@@ -322,8 +295,6 @@ rotate_file()
 
 # Main Loop
 try:
-    zip_previous_day_files()
-
     while True:
         schedule.run_pending()
         data, addr = sock.recvfrom(PACKET_SIZE)

--- a/az_encoder/scripts/cgem_az_encoder.py
+++ b/az_encoder/scripts/cgem_az_encoder.py
@@ -338,8 +338,8 @@ try:
     while True:
         schedule.run_pending()
         data, addr = sock.recvfrom(PACKET_SIZE)
+        current_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f") 
         if addr[0] == UDP_IP and addr[1] == UDP_PORT:
-            current_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f") 
             process_payload(data[0:], current_time)
         else:
             logger.info(f"Ignored packet from {addr}")

--- a/az_encoder/setup.sh
+++ b/az_encoder/setup.sh
@@ -27,7 +27,10 @@ sudo cp scripts/*.py /az_encoder/scripts/
 echo "Copying systemd service files..."
 sudo cp systemd/*.service /etc/systemd/system/
 
+echo "Creating /az_encoder and logs directory, setting owners/permissions…"
 sudo mkdir -p /az_encoder/logs
+sudo chown -R cgem:cgem_control /az_encoder
+sudo chmod -R 775       /az_encoder
 
 echo "Reloading systemd and enabling services..."
 sudo systemctl daemon-reload

--- a/az_encoder/systemd/cgem_az_encoder.service
+++ b/az_encoder/systemd/cgem_az_encoder.service
@@ -3,11 +3,15 @@ Description=CGEM Azimuth Encoder Data Acquisition Service
 After=network.target
 
 [Service]
+Type=simple
+User=cgem
+Group=cgem_control
+WorkingDirectory=/az_encoder
 ExecStart=/environments/cgem_az_encoder/bin/python /az_encoder/scripts/cgem_az_encoder.py
 Restart=on-failure
-KillSignal=SIGQUIT
-StandardOutput=append:/cgem_az_encoder/logs/cg_az_encoder.log
-StandardError=append:/cgem_az_encoder/logs/cg_az_encoder.log
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target
+


### PR DESCRIPTION
This PR addresses two issues:

- #7 : we are now creating the timestamps upon reception of the UDP packets
- removed a leftover function whose purpose was to zip the encoder files every day. This was not intended to be used and was leftover in the deployed code. 